### PR TITLE
set dependencies on fixed dal, add idea config files to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ yotta_targets
 Makefile.local
 ext
 upload.tar.gz
+*.iml
+.idea

--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/microsoft/pxt-calliope-core",
   "license": "MIT",
   "dependencies": {
-    "microbit": "calliope-mini/microbit#v0.2.0-calliope"
+    "microbit": "calliope-mini/microbit#v0.2.1-calliope"
   },
   "targetDependencies": {},
   "extraIncludes": [


### PR DESCRIPTION
basically just set the dependency to a fixed version of the dal, which had a leftover serial in the accelerometer code which prevented it from working in some cases.
